### PR TITLE
Turn the alpha down on the "highlighted line" background color

### DIFF
--- a/themes/main.css
+++ b/themes/main.css
@@ -494,7 +494,7 @@
 
 /* Highlight the current line into code mirror */
 .cm2-activeline {
-    background: #f8f7f6 !important;
+    background: rgba(248, 247, 246, 0.25) !important;
 }
 
 .x-box-like {


### PR DESCRIPTION
The background color on highlighted lines can be pretty unreadable in the "dark" themes. This turns the alpha down so it doesn't burn your retinas out.
