### PR TITLE
Improve documentNotUTF8 check in ToolsError for HTML support

### DIFF
--- a/php/ToolsError.php
+++ b/php/ToolsError.php
@@ -1346,11 +1346,19 @@ class ToolsError
             $content = $this->lang_content;
         }
 
-        $matches = array();
-        preg_match('!<\?xml(.+)\s?encoding=("|\')(.*)("|\')\s?\?>!U', $content, $matches);
+        $exprs = array(
+            '#<\?xml[^>]+encoding=([\'"])[Uu][Tt][Ff]-8\1#U',
+            '#<meta\s+(?:(?:http-equiv\s*=\s*([\'"])content-type\1\s*)|(?:content\s*=\s*([\'"])text/html\s*;.*charset\s*=\s*utf-?8.*\2\s*)){2}#Ui',
+            '#<meta\s+charset\s*=\s*([\'"])utf-?8\1#Ui',
+        );
 
-        if ( !isset($matches[3]) || strtoupper($matches[3]) != 'UTF-8') {
+        foreach ($exprs as $expr) {
+            if ( $match = preg_match($expr, $content) ) {
+                break;
+            }
+        }
 
+        if (!$match) {
             $this->addError(array(
                 'value_en'   => 'N/A',
                 'value_lang' => 'N/A',


### PR DESCRIPTION
Improve documentNotUTF8 check to allow <meta> character set declarations in HTML documents:
- Considers `<meta http-equiv="content-type" content="text/html; charset=UTF-8">` to be a valid charset declaration
- Considers `<meta charset="UTF-8">` to be a valid charset declaration
- Permits the encoding attribute of the relevant tag to appear anywhere within the tag (currently in the `<?xml` variant it must be the last attribute)
- Permits the HTML variants to specify `UTF8` as well as `UTF-8` (all browsers forgive this mistake and understand it). The XML variant remains strict on this point.
