### PR TITLE
fixed mixed content errors in patch preview

### DIFF
--- a/js/ui/cmp/MainPanel.js
+++ b/js/ui/cmp/MainPanel.js
@@ -424,7 +424,7 @@ ui.cmp.MainPanel = Ext.extend(Ext.ux.SlidingTabPanel, {
             // Load diff data only if FilePath & FileName exist
             if( FilePath !== '' && FileName !== '' )
             {
-                previewUrl = 'http://' + window.location.host + ':' +
+                previewUrl = 'https://' + window.location.host + ':' +
                                  window.location.port + '/diffPreview.php';
                 
                 XHR({
@@ -437,7 +437,7 @@ ui.cmp.MainPanel = Ext.extend(Ext.ux.SlidingTabPanel, {
                         
                         if( o.url === '404' ) {
                             
-                            urlSite = 'http://' + window.location.host + ':' +
+                            urlSite = 'https://' + window.location.host + ':' +
                                  window.location.port + '/diffPreview.php?'+Ext.urlEncode({
                                      msg: _('Documentation page not available')
                                 });
@@ -463,7 +463,7 @@ ui.cmp.MainPanel = Ext.extend(Ext.ux.SlidingTabPanel, {
                     }
                 });  
             } else {
-                previewUrl = 'http://' + window.location.host + ':' +
+                previewUrl = 'https://' + window.location.host + ':' +
                                  window.location.port + '/diffPreview.php?'+Ext.urlEncode({
                                      msg: _('Documentation page not available')
                                 });


### PR DESCRIPTION
I guess this patch fixes my mixed content errors I see in firefox nightly.

I found the "same mistake" also in `main-all-debug.js` and in `main-all.js` but I guess those files are build from the other source files. If I am wrong please give me a ping and I will patch those the same way.

![image](https://cloud.githubusercontent.com/assets/120441/24850362/01f41f28-1dd0-11e7-8791-860e30cf02db.png)

Repro:
- open https://edit.php.net in FF nightly (guess the same for the stable FF)
- "Patches for review"
- open a patch you already sent into the queue by right click "view diff" (context menu)