### PR TITLE
fixed possible mixed-content errors in main-panel

### DIFF
--- a/js/ui/cmp/MainPanel.js
+++ b/js/ui/cmp/MainPanel.js
@@ -526,13 +526,11 @@ ui.cmp.MainPanel = Ext.extend(Ext.ux.SlidingTabPanel, {
                             patchPermLink='';
                         
                         if( patchID == '' ) {
-                            patchPermLink = '<a href="http://' + window.location.host + ':' +
-                                    window.location.port + window.location.pathname +
+                            patchPermLink = '<a href="' + window.location.pathname +
                                     '?patch='+FilePath+FileName+'&project=' + PhDOE.project + '"><h2>' +
                                     _('Direct link to this patch')+' ; ' + _('File: ') + FilePath+FileName+'</h2></a>';
                         } else {
-                            patchPermLink = '<a href="http://' + window.location.host + ':' +
-                                    window.location.port + window.location.pathname +
+                            patchPermLink = '<a href="' + window.location.pathname +
                                     '?patchID='+patchID+'&project=' + PhDOE.project + '"><h2>' +
                                     _('Direct link to this patch')+' ; ' + _('Patch Name: ') + patchName+'</h2></a>';
                         }


### PR DESCRIPTION
I wasnt able to test it and I am not 100% confident whether this fix breaks something (as I am not able to test it locally).

the urls as is will direct the user to the non-https site, even if he is on a secure connection at the time of clicking.